### PR TITLE
feat: add template for PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+### Description
+
+Please provide a brief description of the changes you have made in your PR.
+
+### Type of change
+
+- [ ] Feature (introduces new functionality)
+- [ ] Bugfix
+- [ ] Configuration
+- [ ] Refactoring (doesn't change functionality, only the code)
+- [ ] Style changes (doesn't affect functionality, only the look of the components)
+
+### PR Checklist
+
+- [ ] Synced up with latest from the main branch/Code is linted
+- [ ] Description of the changes has been added (Screenshots/Video)
+
+> If not explain here
+
+- [ ] Commit messages follow [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary)
+- [ ] Console has been checked for warnings
+
+#### Screenshots/Video before change
+
+Add screenshots of the changed components here.
+
+#### Screenshots/Video after change
+
+Add screenshots with the changes applied here.


### PR DESCRIPTION
### Description

Added a template for PR descriptions in GitHub.

### Type of change

- [x] Feature (introduces new functionality)
- [ ] Bugfix
- [ ] Configuration
- [ ] Refactoring (doesn't change functionality, only the code)
- [ ] Style changes (doesn't affect functionality, only the look of the components)

### PR Checklist

- [x] Synced up with latest from the main branch/Code is linted
- [x] Description of the changes has been added (Screenshots/Video)

> If not explain here

- [x] Commit messages follow [conventional commits guideline](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary)
- [x] Console has been checked for warnings

#### Screenshots/Video before change

Add screenshots of the changed components here.

#### Screenshots/Video after change

Add screenshots with the changes applied here.
